### PR TITLE
New block interactions + Metal Cap idea

### DIFF
--- a/src/main/java/com/dylanpdx/retro64/sm64/libsm64/SM64MCharInputs.java
+++ b/src/main/java/com/dylanpdx/retro64/sm64/libsm64/SM64MCharInputs.java
@@ -13,11 +13,12 @@ public class SM64MCharInputs extends Structure {
 	public byte buttonA;
 	public byte buttonB;
 	public byte buttonZ;
+	public byte buttonL,buttonR,buttonU,buttonD;
 	public SM64MCharInputs() {
 		super();
 	}
 	protected List<String> getFieldOrder() {
-		return Arrays.asList("camLookX", "camLookZ","cameraPosition", "stickX", "stickY", "buttonA", "buttonB", "buttonZ");
+		return Arrays.asList("camLookX", "camLookZ","cameraPosition", "stickX", "stickY", "buttonA", "buttonB", "buttonZ", "buttonL", "buttonR", "buttonU", "buttonD");
 	}
 	public SM64MCharInputs(float camLookX, float camLookZ, float stickX, float stickY, byte buttonA, byte buttonB, byte buttonZ) {
 		super();

--- a/src/main/java/com/dylanpdx/retro64/sm64/libsm64/SM64MCharState.java
+++ b/src/main/java/com/dylanpdx/retro64/sm64/libsm64/SM64MCharState.java
@@ -8,6 +8,10 @@ public class SM64MCharState extends Structure {
 	public float[] position = new float[3];
 	/** C type : float[3] */
 	public float[] velocity = new float[3];
+	/** C type : float[3] */
+	public float[] camPos = new float[3];
+	/** C type : float[3] */
+	public float[] camFocus = new float[3];
 	public float faceAngle;
 	public short health;
 	public int flags;
@@ -17,7 +21,7 @@ public class SM64MCharState extends Structure {
 		super();
 	}
 	protected List<String> getFieldOrder() {
-		return Arrays.asList("position", "velocity", "faceAngle", "health", "flags", "action","currentModel");
+		return Arrays.asList("position", "velocity","camPos","camFocus", "faceAngle", "health", "flags", "action","currentModel");
 	}
 
 	public SM64MCharState(float position[], float velocity[], float faceAngle, short health, int flags, int action, int currentModel) {


### PR DESCRIPTION
-Blue Ice block: Make Mario flinch like the frozen lake from SL
-Wither rose block: Gave Mario the same effect as the toxic cloud from HMC
-Slime block: Launch Mario into the air and make him whirl like the Flower Head enemy
-Wooden Fence: Function as a pole

Sugestions:
-Make Scaffolding and Big Dripleaf one-way platforms
-Allow Carpet and Lily pad blocks to be standables
-Crawling Mario should be able to enter 1x1 spaces 
-Turtle Shell grants the Metal Mario effect when equiped (like the elytra grants the Flying Cap)
