### PR TITLE
Fix for lower-left quadrant of controller lacking analog control

### DIFF
--- a/src/main/java/com/dylanpdx/retro64/SM64EnvManager.java
+++ b/src/main/java/com/dylanpdx/retro64/SM64EnvManager.java
@@ -126,7 +126,7 @@ public class SM64EnvManager {
         selfMChar.inputs.stickX=0;
         selfMChar.inputs.stickY=0;
         Vec2 v2=null;
-        if (Retro64.hasControllerSupport && (clientControllerEvents.input.x>0 || clientControllerEvents.input.y>0)){
+        if (Retro64.hasControllerSupport && (clientControllerEvents.input.x != 0 || clientControllerEvents.input.y != 0)){
             v2 = clientControllerEvents.input;
         }else{
             if (W_pressed) selfMChar.inputs.stickX += 1;


### PR DESCRIPTION
Found the fix for the issue I created previously. (Retro64Mod/Retro64Mod.github.io#45)

### Explanation for the curious cats who may look here:
The controller input was previously only used properly if the `x` or `y` values of the input were positive. This check is flawed, however, because with the stick held in the lower left quadrant, `x` and `y` are both negative, which fails the check (and Controllable would take over to make the input act like the A and S keyboard keys). I addressed this by changing the check to see if `x` or `y` is nonzero instead of just greater than zero.