### PR TITLE
Add "się" before "crashować" in "menu.retro64.genericWarn" for better Polish grammar.

### DIFF
--- a/src/main/resources/assets/retro64/lang/pl_pl.json
+++ b/src/main/resources/assets/retro64/lang/pl_pl.json
@@ -12,7 +12,7 @@
   "charSelect.retro64.prev": "Poprzedni",
   "charSelect.retro64.next": "Dalej",
   "menu.retro64.ok": "Rozumiem",
-  "menu.retro64.genericWarn": "Proszę zapoznać się z instrukcją instalacji. Mod może nie działać poprawnie w tym stanie, lub gra może crashować.",
+  "menu.retro64.genericWarn": "Proszę zapoznać się z instrukcją instalacji. Mod może nie działać poprawnie w tym stanie, lub gra może się crashować.",
   "menu.retro64.warnNoDLL": "Brakuje pliku sm64.dll.",
   "menu.retro64.warnWrongVersion": "Masz złą wersje sm64.dll, możliwe że musisz go skompilować ponownie.",
   "menu.retro64.warnMissingROM": "Brakuje pliku rom.",


### PR DESCRIPTION
Add "się" before "crashować" in "menu.retro64.genericWarn" for better Polish grammar.